### PR TITLE
Add XSLT Playground to Online Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ A small excerpt of the many online tools for XML processing.
 - Code Beautify XML Tools - [Coverter](https://codebeautify.org/xml-converter-online), [Generator](https://codebeautify.org/generate-random-xml), [Difftool](https://codebeautify.org/xml-diff), [Minify](https://codebeautify.org/xml-minifier), [Editor](https://codebeautify.org/online-xml-editor), [Parser](https://codebeautify.org/xml-parser-online), [Validator](https://codebeautify.org/xmlvalidator), [Viewer](https://codebeautify.org/xmlviewer)
 - ExtendsClass XML Tools - [Difftool](https://extendsclass.com/xml-diff.html), [Formatter](https://extendsclass.com/xml-formatter-online.html), [Generator](https://extendsclass.com/xml-generator.html), [Validator](https://extendsclass.com/xml-validator.html), [XSD Generator](https://extendsclass.com/xml-schema-validator.html)
 - XMLable XML Tools - [Formatter](https://xmlable.com/formatter/), [Validator](https://xmlable.com/validator/), [XSD Generator](https://xmlable.com/xml-to-xsd/), [XPath tester](https://xmlable.com/xpath/), [Difftool](https://xmlable.com/compare/), [Generator](https://xmlable.com/generator/), [XSL Transformation](https://xmlable.com/xslt/)
+- XSLT Playground - [XSL Transformer](https://xsltplayground.com/) (XSLT 1.0, [2.0](https://xsltplayground.com/xslt-2-0/), [3.0](https://xsltplayground.com/xslt-3-0/) via Saxon HE — the only free online tool supporting XSLT 3.0)
 
 <p align="right"><a href="#contents"><b>↥ back to top ↥</b></a></p>
 


### PR DESCRIPTION
## What

Adds [XSLT Playground](https://xsltplayground.com/) to the Online Tools section.

## Why

XSLT Playground is the only free online tool that supports **XSLT 1.0, 2.0 and 3.0** via Saxon HE 12.5. Every other free online XSL transformer (including FreeFormatter, XMLable, etc.) is limited to XSLT 1.0. It fills a notable gap in the list.

Links included:
- Main editor (XSLT 1.0/2.0/3.0): https://xsltplayground.com/
- XSLT 2.0 tester: https://xsltplayground.com/xslt-2-0/
- XSLT 3.0 tester: https://xsltplayground.com/xslt-3-0/